### PR TITLE
no longer building srg jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ minecraft {
     version = "1.12.2-14.23.4.2705"
     runDir = "run"
     mappings = "snapshot_20171003"
-    // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
+    makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
     replace '@VERSION@', project.version
     replace '@MODID@', modid


### PR DESCRIPTION
no longer buildign srg jar (caused by lambdas), fixes any further build hangs.