### PR TITLE
Disables the incomplete Scar feature (resolves #75)

### DIFF
--- a/src/main/java/hu/frontrider/arcana/eventhandlers/ScarEvents.kt
+++ b/src/main/java/hu/frontrider/arcana/eventhandlers/ScarEvents.kt
@@ -1,21 +1,41 @@
-package hu.frontrider.arcana.eventhandlers
+package hu.frontrider.arcana.research.researchevents
 
 import hu.frontrider.arcana.capabilities.scar.ScarProvider
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.util.DamageSource
+import net.minecraftforge.event.entity.living.LivingEvent
 import net.minecraftforge.event.entity.living.LivingHurtEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+import thaumcraft.api.capabilities.ThaumcraftCapabilities.KNOWLEDGE
 
-class ScarEvents {
+class TheScar {
 
-    //@SubscribeEvent
-    fun damage(event:LivingHurtEvent){
-
-        val entity = event.entity
-
-        if(entity.hasCapability(ScarProvider.SCARRED_CAPABILITY,null)){
-            val capability = entity.getCapability(ScarProvider.SCARRED_CAPABILITY, null)!!
-            capability.currentDamage+= event.amount
-            capability.limbs.hurt(event.amount/2,entity.world.rand)
+    @SubscribeEvent
+    fun damageEvent(event: LivingHurtEvent) {
+        val player = event.entity
+        if (player is EntityPlayer) {
+            val knowledge = player.getCapability(KNOWLEDGE, null)!!
+            if (knowledge.isResearchComplete("BIOMANCY_BASICS")) {
+                val capability = player.getCapability(ScarProvider.SCARRED_CAPABILITY, null)!!
+                //capability.currentDamage += event.amount
+            }
         }
-
     }
+
+    @SubscribeEvent
+    fun tickEvent(event: LivingEvent.LivingUpdateEvent) {
+        val player = event.entity
+        /* if (player is EntityPlayer) {
+            val knowledge = player.getCapability(KNOWLEDGE, null)!!
+            if (knowledge.isResearchComplete("BIOMANCY_BASICS")) {
+                val capability = player.getCapability(ScarProvider.SCARRED_CAPABILITY, null)!!
+                if (capability.currentDamage > capability.requiredDamage) {
+                    if (player.health > player.maxHealth - capability.severity)
+                        player.attackEntityFrom(DamageSource.GENERIC, capability.severity.toFloat())
+                }
+            }
+        } */
+    }
+
+
 }


### PR DESCRIPTION
Because the Scar mechanic was incomplete, it was causing players to take unexplained damage from an unidentified source, with no way to remove the effect except to die. I've commented out some of the code to disable the mechanic while leaving the code in place for any future development of the feature.