### PR TITLE
Fixes research using wrong items

### DIFF
--- a/src/main/java/hu/frontrider/arcana/research/theory/TheoryRegistry.kt
+++ b/src/main/java/hu/frontrider/arcana/research/theory/TheoryRegistry.kt
@@ -35,14 +35,14 @@ class TheoryRegistry {
         itemStacks.add(ItemStack(MUTTON))
         itemStacks.add(ItemStack(PORKCHOP))
 
-        CardGrow.options = itemStacks.toTypedArray()
+        CardDissect.options = itemStacks.toTypedArray()
 
         itemStacks.clear()
         itemStacks.add(ItemStack(ItemsTC.brain))
         itemStacks.add(ItemStack(ROTTEN_FLESH))
         itemStacks.add(ItemStack(BONE))
 
-        CardGrow.options = itemStacks.toTypedArray()
+        CardDissectDead.options = itemStacks.toTypedArray()
 
     }
 }


### PR DESCRIPTION
Previously, "Grow" research required rotten flesh, bones, or zombie brains, and "Dissect" research required wheat seeds. This should fix that.